### PR TITLE
Add annotations for all DTO fields

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -39,9 +39,7 @@ dependencies {
 
 
     implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.0-RC2"
-    //GSON
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.0"
     testImplementation "io.mockk:mockk:$mockk_version"
 }
 

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/DateSerializer.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/DateSerializer.kt
@@ -1,0 +1,24 @@
+package com.thenewboston.data.dto.bankapi
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.text.SimpleDateFormat
+import java.util.*
+
+object DateSerializer : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Date", PrimitiveKind.LONG)
+    override fun serialize(encoder: Encoder, value: Date) {
+        //ignored
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        val string = decoder.decodeString()
+        val format = SimpleDateFormat("yyyy-mm-dd", Locale.ROOT)
+
+        return format.parse(string)
+    }
+}

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/accountdto/AccountDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/accountdto/AccountDTO.kt
@@ -1,15 +1,26 @@
 package com.thenewboston.data.dto.bankapi.accountdto
 
-import com.google.gson.annotations.SerializedName
+import com.thenewboston.data.dto.bankapi.DateSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
+@Serializable
 data class AccountDTO(
+    @SerialName("id")
     val id: String,
-    @SerializedName("created_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("created_date")
     val createdDate: Date,
-    @SerializedName("modified_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("modified_date")
     val modifiedDate: Date?,
-    @SerializedName("account_number")
+
+    @SerialName("account_number")
     val accountNumber: String,
+
+    @SerialName("trust")
     val trust: Double
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/bankdto/BankDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/bankdto/BankDTO.kt
@@ -1,18 +1,32 @@
 package com.thenewboston.data.dto.bankapi.bankdto
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+
+@Serializable
 data class BankDTO(
-    @SerializedName("account_number")
+    @SerialName("account_number")
     val accountNumber: String,
-    @SerializedName("ip_address")
+
+    @SerialName("ip_address")
     val ipAddress: String,
-    @SerializedName("node_identifier")
+
+    @SerialName("node_identifier")
     val nodeIdentifier: String,
+
+    @SerialName("port")
     val port: Int? = null,
+
+    @SerialName("protocol")
     val protocol: String,
+
+    @SerialName("version")
     val version: String,
-    @SerializedName("default_transaction_fee")
+
+    @SerialName("default_transaction_fee")
     val defaultTransactionFee: Double,
+
+    @SerialName("trust")
     val trust: Double
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BankTransactionDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BankTransactionDTO.kt
@@ -1,8 +1,19 @@
 package com.thenewboston.data.dto.bankapi.banktransactiondto
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class BankTransactionDTO(
+    @SerialName("id")
     val id: String,
+
+    @SerialName("block")
     val block: BlockDTO,
+
+    @SerialName("amount")
     val amount: Double,
+
+    @SerialName("recipient")
     val recipient: String
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BlockDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BlockDTO.kt
@@ -1,16 +1,29 @@
 package com.thenewboston.data.dto.bankapi.banktransactiondto
 
-import com.google.gson.annotations.SerializedName
+import com.thenewboston.data.dto.bankapi.DateSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
+@Serializable
 data class BlockDTO(
+    @SerialName("id")
     val id: String,
-    @SerializedName("created_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("created_date")
     val createdDate: Date,
-    @SerializedName("modified_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("modified_date")
     val modifiedDate: Date?,
-    @SerializedName("balance_key")
+
+    @SerialName("balance_key")
     val balanceKey: String,
+
+    @SerialName("sender")
     val sender: String,
+
+    @SerialName("signature")
     val signature: String
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/configdto/ConfigDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/configdto/ConfigDTO.kt
@@ -1,44 +1,73 @@
 package com.thenewboston.data.dto.bankapi.configdto
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ConfigDTO(
-    @SerializedName("primary_validator")
+    @SerialName("primary_validator")
     val primaryValidator: PrimaryValidator,
-    @SerializedName("account_number")
+
+    @SerialName("account_number")
     val accountNumber: String,
-    @SerializedName("ip_address")
+
+    @SerialName("ip_address")
     val ipAddress: String,
-    @SerializedName("node_identifier")
+
+    @SerialName("node_identifier")
     val nodeIdentifier: String,
+
+    @SerialName("port")
     val port: Int,
+
+    @SerialName("protocol")
     val protocol: String,
+
+    @SerialName("version")
     val version: String,
-    @SerializedName("default_transaction_fee")
+
+    @SerialName("default_transaction_fee")
     val defaultTransactionFee: Double,
-    @SerializedName("node_type")
+
+    @SerialName("node_type")
     val nodeType: String
 )
 
+@Serializable
 data class PrimaryValidator(
-    @SerializedName("account_number")
+    @SerialName("account_number")
     val accountNumber: String,
-    @SerializedName("ip_address")
+
+    @SerialName("ip_address")
     val ipAddress: String,
-    @SerializedName("node_identifier")
+
+    @SerialName("node_identifier")
     val nodeIdentifier: String,
+
+    @SerialName("port")
     val port: Int,
+
+    @SerialName("protocol")
     val protocol: String,
+
+    @SerialName("version")
     val version: String,
-    @SerializedName("default_transaction_fee")
+
+    @SerialName("default_transaction_fee")
     val defaultTransactionFee: Double,
-    @SerializedName("root_account_file")
+
+    @SerialName("root_account_file")
     val rootAccountFile: String,
-    @SerializedName("root_account_file_hash")
+
+    @SerialName("root_account_file_hash")
     val rootAccountFileHash: String,
-    @SerializedName("seed_block_identifier")
+
+    @SerialName("seed_block_identifier")
     val seedBlockIdentifier: String,
-    @SerializedName("daily_confirmation_rate")
+
+    @SerialName("daily_confirmation_rate")
     val dailyConfirmationRate: Double? = null,
+
+    @SerialName("trust")
     val trust: Double
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/confirmationblockdto/ConfirmationBlockDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/confirmationblockdto/ConfirmationBlockDTO.kt
@@ -1,16 +1,29 @@
 package com.thenewboston.data.dto.bankapi.confirmationblockdto
 
-import com.google.gson.annotations.SerializedName
+import com.thenewboston.data.dto.bankapi.DateSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
+@Serializable
 data class ConfirmationBlockDTO(
+    @SerialName("id")
     val id: Int,
-    @SerializedName("created_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("created_date")
     val createdDate: Date,
-    @SerializedName("modified_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("modified_date")
     val modifiedDate: Date?,
-    @SerializedName("block_identifier")
+
+    @SerialName("block_identifier")
     val blockIdentifier: String,
+
+    @SerialName("block")
     val block: Int,
+
+    @SerialName("validator")
     val validator: Int
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/invalidblockdto/InvalidBlockDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/invalidblockdto/InvalidBlockDTO.kt
@@ -1,19 +1,32 @@
 package com.thenewboston.data.dto.bankapi.invalidblockdto
 
-import com.google.gson.annotations.SerializedName
+import com.thenewboston.data.dto.bankapi.DateSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
+@Serializable
 data class InvalidBlockDTO(
+    @SerialName("id")
     val id: String,
-    @SerializedName("created_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("created_date")
     val createdDate: Date,
-    @SerializedName("modified_date")
+
+    @Serializable(with = DateSerializer::class)
+    @SerialName("modified_date")
     val modifiedDate: Date?,
-    @SerializedName("block_identifier")
+
+    @SerialName("block_identifier")
     val blockIdentifier: String,
+
+    @SerialName("block")
     val block: String,
-    @SerializedName("confirmation_validator")
+
+    @SerialName("confirmation_validator")
     val confirmationValidator: String,
-    @SerializedName("primary_validator")
+
+    @SerialName("primary_validator")
     val primaryValidator: String
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/validatorconfirmationservicesdto/ValidatorConfirmationServicesDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/validatorconfirmationservicesdto/ValidatorConfirmationServicesDTO.kt
@@ -1,15 +1,24 @@
 package com.thenewboston.data.dto.bankapi.validatorconfirmationservicesdto
 
-import com.google.gson.annotations.SerializedName
-import java.util.Date
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+
+@Serializable
 data class ValidatorConfirmationServicesDTO(
     val id: String,
-    @SerializedName("created_date")
-    val createdDate: Date,
-    @SerializedName("modified_date")
-    val modifiedDate: Date?,
-    val end: Date,
-    val start: Date,
+    @SerialName("created_date")
+    val createdDate: String,
+
+    @SerialName("modified_date")
+    val modifiedDate: String?,
+
+    @SerialName("end")
+    val end: String,
+
+    @SerialName("start")
+    val start: String,
+
+    @SerialName("validator")
     val validator: String
 )

--- a/lib/src/main/java/com/thenewboston/data/dto/bankapi/validatordto/ValidatorDTO.kt
+++ b/lib/src/main/java/com/thenewboston/data/dto/bankapi/validatordto/ValidatorDTO.kt
@@ -1,26 +1,44 @@
 package com.thenewboston.data.dto.bankapi.validatordto
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+
+@Serializable
 data class ValidatorDTO(
-    @SerializedName("account_number")
+    @SerialName("account_number")
     val accountNumber: String,
-    @SerializedName("ip_address")
+
+    @SerialName("ip_address")
     val ipAddress: String,
-    @SerializedName("node_identifier")
+
+    @SerialName("node_identifier")
     val nodeIdentifier: String,
+
+    @SerialName("port")
     val port: Int,
+
+    @SerialName("protocol")
     val protocol: String,
+
+    @SerialName("version")
     val version: String,
-    @SerializedName("default_transaction_fee")
+
+    @SerialName("default_transaction_fee")
     val defaultTransactionFee: Double,
-    @SerializedName("root_account_file")
+
+    @SerialName("root_account_file")
     val rootAccountFile: String,
-    @SerializedName("root_account_file_hash")
+
+    @SerialName("root_account_file_hash")
     val rootAccountFileHash: String,
-    @SerializedName("seed_block_identifier")
+
+    @SerialName("seed_block_identifier")
     val seedBlockIdentifier: String,
-    @SerializedName("daily_confirmation_rate")
+
+    @SerialName("daily_confirmation_rate")
     val dailyConfirmationRate: Double? = null,
+
+    @SerialName("trust")
     val trust: Double
 )

--- a/lib/src/main/java/com/thenewboston/validator/model/response/Validator.kt
+++ b/lib/src/main/java/com/thenewboston/validator/model/response/Validator.kt
@@ -6,23 +6,37 @@ import kotlinx.serialization.SerialName
 data class Validator(
     @SerialName("account_number")
     val accountNumber: String,
+
     @SerialName("ip_address")
     val ipAddress: String,
+
     @SerialName("node_identifier")
     val nodeIdentifier: String,
+
+    @SerialName("port")
     val port: Int,
+
+    @SerialName("protocol")
     val protocol: String,
+
+    @SerialName("version")
     val version: String,
+
     @SerialName("default_transaction_fee")
     val defaultTransactionFee: BigDecimal,
+
     @SerialName("root_account_file")
     val rootAccountFile: String,
+
     @SerialName("root_account_file_hash")
     val rootAccountFileHash: String,
+
     @SerialName("seed_block_identifier")
     val seedBlockIdentifier: String,
+
     @SerialName("daily_confirmation_rate")
     val dailyConfirmationRate: BigDecimal,
+
     @SerialName("trust")
     val trust: BigDecimal
 )

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/accountdto/AccountDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/accountdto/AccountDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.accountdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -36,8 +37,7 @@ class AccountDTOTest {
 
     @Test
     fun accountsTest() {
-        val accounts: List<AccountDTO> =
-            Gson().fromJson(jsonStringArray, Array<AccountDTO>::class.java).toList()
+        val accounts: List<AccountDTO> = Json.decodeFromString(jsonStringArray)
 
         accounts.forEachIndexed { index, accountDTO ->
             assertEquals(ids[index], accountDTO.id)

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/bankdto/BankDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/bankdto/BankDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.bankdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -47,8 +48,7 @@ class BankDTOTest {
 
     @Test
     fun bankTest() {
-        val banks: List<BankDTO> =
-            Gson().fromJson(jsonStringArray, Array<BankDTO>::class.java).toList()
+        val banks: List<BankDTO> = Json.decodeFromString(jsonStringArray)
 
         banks.forEachIndexed { index, bankDTO ->
             Assertions.assertEquals(accountNumbers[index], bankDTO.accountNumber)

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BankTransactionDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/banktransactiondto/BankTransactionDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.banktransactiondto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -69,8 +70,7 @@ class BankTransactionDTOTest {
 
     @Test
     fun bankTransactionsTest() {
-        val transactions =
-            Gson().fromJson(jsonStringArray, Array<BankTransactionDTO>::class.java).toList()
+        val transactions : List<BankTransactionDTO> = Json.decodeFromString(jsonStringArray)
 
         transactions.forEachIndexed { index, bankTransactionDTO ->
             assertEquals(ids[index], bankTransactionDTO.id)

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/configdto/ConfigDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/configdto/ConfigDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.configdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -37,7 +38,8 @@ class ConfigDTOTest {
 
     @Test
     fun configTest() {
-        val config = Gson().fromJson(jsonString, ConfigDTO::class.java)
+        val config: ConfigDTO = Json.decodeFromString(jsonString)
+
         val primaryValidator = config.primaryValidator
 
         primaryValidator.apply {
@@ -57,8 +59,8 @@ class ConfigDTOTest {
             assertEquals(4.0000000000000000, defaultTransactionFee)
             assertEquals(
                 "https://gist.githubusercontent.com/" +
-                    "buckyroberts/519b5cb82a0a5b5d4ae8a2175b722520/" +
-                    "raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json",
+                        "buckyroberts/519b5cb82a0a5b5d4ae8a2175b722520/" +
+                        "raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json",
                 rootAccountFile
             )
             assertEquals(

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/confirmationblockdto/ConfirmationBlockDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/confirmationblockdto/ConfirmationBlockDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.confirmationblockdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -18,8 +19,7 @@ class ConfirmationBlockDTOTest {
 
     @Test
     fun confirmationBlockTest() {
-        val confBlock = Gson().fromJson(jsonString, ConfirmationBlockDTO::class.java)
-
+        val confBlock: ConfirmationBlockDTO = Json.decodeFromString(jsonString)
         confBlock.apply {
             assertEquals(1, id)
 

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/invalidblockdto/InvalidBlockDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/invalidblockdto/InvalidBlockDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.invalidblockdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -20,7 +21,7 @@ class InvalidBlockDTOTest {
 
     @Test
     fun invalidBlockTest() {
-        val invalidBlock = Gson().fromJson(jsonString, InvalidBlockDTO::class.java)
+        val invalidBlock: InvalidBlockDTO = Json.decodeFromString(jsonString)
 
         invalidBlock.apply {
             assertEquals("2bcd53c5-19f9-4226-ab04-3dfb17c3a1fe", id)

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/validatorconfirmationservicesdto/ValidatorConfirmationServicesDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/validatorconfirmationservicesdto/ValidatorConfirmationServicesDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.validatorconfirmationservicesdto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -38,9 +39,7 @@ class ValidatorConfirmationServicesDTOTest {
 
     @Test
     fun validatorConfirmationServicesTest() {
-        val services =
-            Gson().fromJson(jsonStringArray, Array<ValidatorConfirmationServicesDTO>::class.java)
-                .toList()
+        val services: List<ValidatorConfirmationServicesDTO> = Json.decodeFromString(jsonStringArray)
 
         services.forEachIndexed { index, validatorConfirmationServicesDTO ->
             assertEquals(ids[index], validatorConfirmationServicesDTO.id)

--- a/lib/src/test/java/com/thenewboston/data/dto/bankapi/validatordto/ValidatorDTOTest.kt
+++ b/lib/src/test/java/com/thenewboston/data/dto/bankapi/validatordto/ValidatorDTOTest.kt
@@ -1,6 +1,7 @@
 package com.thenewboston.data.dto.bankapi.validatordto
 
-import com.google.gson.Gson
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -24,9 +25,9 @@ class ValidatorDTOTest {
     private val dailyRate = 1.2000000000000000
     private val rootFiles = listOf<String>(
         "https://gist.githubusercontent.com/buckyroberts/" +
-            "519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json",
+                "519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json",
         "https://gist.githubusercontent.com/buckyroberts/" +
-            "519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json"
+                "519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json"
     )
     private val rootHashes = listOf<String>(
         "4694e1ee1dcfd8ee5f989e59ae40a9f751812bf5ca52aca2766b322c4060672b",
@@ -68,7 +69,7 @@ class ValidatorDTOTest {
 
     @Test
     fun validatorTest() {
-        val validator = Gson().fromJson(jsonStringArray, Array<ValidatorDTO>::class.java).toList()
+        val validator: List<ValidatorDTO> = Json.decodeFromString(jsonStringArray)
 
         validator.forEachIndexed { index, validatorDTO ->
             assertEquals(accountNumbers[index], validatorDTO.accountNumber)


### PR DESCRIPTION
Changes in this Pull Request

1. Annotate all DTO fields with `@SerialName` #37 
2. Remove dependency on gson so we only use `kotlinx.serialization` now. #36 
3. Add a custom serializer for serializing `java.util.Date` types in DTO