### PR TITLE
Remove multiple instances of HttpClient in mock tests

### DIFF
--- a/lib/src/main/java/com/thenewboston/api/bankapi/datasource/BankDataSource.kt
+++ b/lib/src/main/java/com/thenewboston/api/bankapi/datasource/BankDataSource.kt
@@ -47,7 +47,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val result = networkClient.defaultClient.get<BankList>(BankAPIEndpoints.BANKS_ENDPOINT)
 
         return when {
-            result.banks.isNullOrEmpty() -> Outcome.Error(ErrorMessages.EMPTY_LIST_MESSAGE, IOException())
+            result.banks.isEmpty() -> Outcome.Error(ErrorMessages.EMPTY_LIST_MESSAGE, IOException())
             else -> Outcome.Success(result)
         }
     }
@@ -117,7 +117,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val accounts = networkClient.defaultClient.get<AccountList>(urlString)
 
         return when {
-            accounts.results.isNullOrEmpty() -> Outcome.Error(
+            accounts.results.isEmpty() -> Outcome.Error(
                 ErrorMessages.EMPTY_LIST_MESSAGE,
                 IOException()
             )
@@ -134,7 +134,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val response = networkClient.defaultClient.get<BlockList>(BankAPIEndpoints.BLOCKS_ENDPOINT)
 
         return when {
-            response.blocks.isNullOrEmpty() -> Outcome.Error(
+            response.blocks.isEmpty() -> Outcome.Error(
                 ErrorMessages.EMPTY_LIST_MESSAGE,
                 IOException()
             )
@@ -200,7 +200,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
             .get<InvalidBlockList>(BankAPIEndpoints.INVALID_BLOCKS_ENDPOINT)
 
         return when {
-            invalidBlocks.results.isNullOrEmpty() -> Outcome.Error(
+            invalidBlocks.results.isEmpty() -> Outcome.Error(
                 "No invalid blocks are available at this time",
                 IOException()
             )
@@ -260,7 +260,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val response = networkClient.defaultClient.get<ConfirmationServicesList>(endpoint)
 
         return when {
-            response.services.isNullOrEmpty() -> {
+            response.services.isEmpty() -> {
                 val message = ErrorMessages.EMPTY_LIST_MESSAGE
                 Outcome.Error(message, IOException())
             }

--- a/lib/src/main/java/com/thenewboston/api/bankapi/datasource/BankDataSource.kt
+++ b/lib/src/main/java/com/thenewboston/api/bankapi/datasource/BankDataSource.kt
@@ -73,7 +73,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val result = networkClient.defaultClient.get<BankTransactionList>(endpoint)
 
         return when {
-            result.bankTransactions.isNullOrEmpty() ->
+            result.bankTransactions.isEmpty() ->
                 Outcome.Error("Error bank transactions", IOException())
             else -> Outcome.Success(result)
         }
@@ -89,7 +89,7 @@ class BankDataSource @Inject constructor(private val networkClient: NetworkClien
         val validators = networkClient.defaultClient.get<ValidatorList>(endpoint)
 
         return when {
-            validators.results.isNullOrEmpty() -> Outcome.Error(ErrorMessages.EMPTY_LIST_MESSAGE, IOException())
+            validators.results.isEmpty() -> Outcome.Error(ErrorMessages.EMPTY_LIST_MESSAGE, IOException())
             else -> Outcome.Success(validators)
         }
     }

--- a/lib/src/test/java/com/thenewboston/utils/BankApiMockEngine.kt
+++ b/lib/src/test/java/com/thenewboston/utils/BankApiMockEngine.kt
@@ -139,16 +139,16 @@ class BankApiMockEngine {
                     sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
                 }
                 request.url.encodedPath.startsWith(BankAPIJsonMapper.CONNECTION_REQUESTS_ENDPOINT) -> {
-                        val content = "Successfully sent connection requests"
-                        val invalidContent = ""
-                        sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
-                    }
-                    else -> {
-                        error("Unhandled ${request.url.encodedPath}")
-                    }
+                    val content = "Successfully sent connection requests"
+                    val invalidContent = ""
+                    sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
+                }
+                else -> {
+                    error("Unhandled ${request.url.encodedPath}")
                 }
             }
         }
+    }
 
     private fun readBlockIdentifierFromRequest(request: HttpRequestData): String =
         request.extract<PostInvalidBlockRequest, String> { it.message.blockIdentifier }

--- a/lib/src/test/java/com/thenewboston/utils/BankApiMockEngine.kt
+++ b/lib/src/test/java/com/thenewboston/utils/BankApiMockEngine.kt
@@ -6,11 +6,7 @@ import com.thenewboston.data.dto.bankapi.common.request.UpdateTrustRequest
 import com.thenewboston.data.dto.bankapi.invalidblockdto.request.PostInvalidBlockRequest
 import com.thenewboston.data.dto.bankapi.validatorconfirmationservicesdto.request.Message
 import com.thenewboston.data.dto.bankapi.validatorconfirmationservicesdto.request.PostConfirmationServicesRequest
-import io.ktor.client.*
 import io.ktor.client.engine.mock.*
-import io.ktor.client.features.*
-import io.ktor.client.features.json.*
-import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.http.HttpStatusCode.Companion.Accepted
@@ -36,75 +32,73 @@ class BankApiMockEngine {
     private val json = listOf(ContentType.Application.Json.toString())
     private val responseHeaders = headersOf("Content-Type" to json)
 
+    private val mockHttpClient = MockHttpClientManager()
+
     private fun getBankMockEngine(sendOnlyErrorResponses: Boolean = false, sendInvalidResponses: Boolean = false) =
-        HttpClient(MockEngine) {
+        mockHttpClient.httpClient {
             val errorContent = BankAPIJsonMapper.mapInternalServerErrorToJson()
-            engine {
-                addHandler { request ->
-                    when (request.url.encodedPath) {
-                        BankAPIJsonMapper.ACCOUNTS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapAccountsToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyAccountsToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.BANKS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapBanksToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyBanksToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.BANK_TRANSACTIONS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapBankTransactionsToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyBankTransactionsToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.BLOCKS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapBlocksToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyBlocksToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.VALIDATORS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapValidatorsToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyValidatorsToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.SINGLE_VALIDATOR_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapValidatorToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyValidatorToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.CONFIG_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapBankDetailToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyBankDetailToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.INVALID_BLOCKS_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapInvalidBlocksToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyInvalidBlocksToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.VALIDATOR_CONFIRMATION_SERVICES_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapValidatorConfirmationServicesToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyValidatorConfirmationServicesToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.CLEAN_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapCleanToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyCleanToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        BankAPIJsonMapper.CRAWL_ENDPOINT -> {
-                            val content = BankAPIJsonMapper.mapCrawlToJson()
-                            val emptyContent = BankAPIJsonMapper.mapEmptyCrawlToJson()
-                            sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
-                        }
-                        else -> {
-                            error("Unhandled ${request.url.encodedPath}")
-                        }
+            it.addHandler { request ->
+                when (request.url.encodedPath) {
+                    BankAPIJsonMapper.ACCOUNTS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapAccountsToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyAccountsToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.BANKS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapBanksToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyBanksToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.BANK_TRANSACTIONS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapBankTransactionsToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyBankTransactionsToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.BLOCKS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapBlocksToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyBlocksToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.VALIDATORS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapValidatorsToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyValidatorsToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.SINGLE_VALIDATOR_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapValidatorToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyValidatorToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.CONFIG_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapBankDetailToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyBankDetailToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.INVALID_BLOCKS_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapInvalidBlocksToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyInvalidBlocksToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.VALIDATOR_CONFIRMATION_SERVICES_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapValidatorConfirmationServicesToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyValidatorConfirmationServicesToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.CLEAN_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapCleanToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyCleanToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    BankAPIJsonMapper.CRAWL_ENDPOINT -> {
+                        val content = BankAPIJsonMapper.mapCrawlToJson()
+                        val emptyContent = BankAPIJsonMapper.mapEmptyCrawlToJson()
+                        sendResponse(content, errorContent, emptyContent, sendOnlyErrorResponses, sendInvalidResponses)
+                    }
+                    else -> {
+                        error("Unhandled ${request.url.encodedPath}")
                     }
                 }
             }
-
-            installJsonFeature()
         }
 
     private fun MockRequestHandleScope.sendResponse(
@@ -122,29 +116,29 @@ class BankApiMockEngine {
     private fun postBankEngine(
         sendOnlyErrorResponses: Boolean = false,
         sendInvalidResponses: Boolean = false
-    ) = HttpClient(MockEngine) {
+    ) = mockHttpClient.httpClient {
         val errorContent = BankAPIJsonMapper.mapInternalServerErrorToJson()
 
-        engine {
-            addHandler { request ->
-                when {
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.VALIDATOR_CONFIRMATION_SERVICES_ENDPOINT) -> {
-                        val content = BankAPIJsonMapper.mapValidatorConfirmationServiceToJson(readMessageFromRequest(request))
-                        val invalidContent = BankAPIJsonMapper.mapEmptyValidatorConfirmationServiceToJson()
-                        sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.UPGRADE_NOTICE_ENDPOINT) -> {
-                        val content = "Successfully sent upgrade notice"
-                        val invalidContent = ""
-                        sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.CLEAN_ENDPOINT) -> {
-                        val clean = readCleanFromRequest(request)
-                        val content = BankAPIJsonMapper.mapCleanToJson(clean)
-                        val invalidContent = BankAPIJsonMapper.mapCleanResponseForPostRequest()
-                        sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.CONNECTION_REQUESTS_ENDPOINT) -> {
+        it.addHandler { request ->
+            when {
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.VALIDATOR_CONFIRMATION_SERVICES_ENDPOINT) -> {
+                    val content =
+                        BankAPIJsonMapper.mapValidatorConfirmationServiceToJson(readMessageFromRequest(request))
+                    val invalidContent = BankAPIJsonMapper.mapEmptyValidatorConfirmationServiceToJson()
+                    sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
+                }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.UPGRADE_NOTICE_ENDPOINT) -> {
+                    val content = "Successfully sent upgrade notice"
+                    val invalidContent = ""
+                    sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
+                }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.CLEAN_ENDPOINT) -> {
+                    val clean = readCleanFromRequest(request)
+                    val content = BankAPIJsonMapper.mapCleanToJson(clean)
+                    val invalidContent = BankAPIJsonMapper.mapCleanResponseForPostRequest()
+                    sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
+                }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.CONNECTION_REQUESTS_ENDPOINT) -> {
                         val content = "Successfully sent connection requests"
                         val invalidContent = ""
                         sendResponse(content, errorContent, invalidContent, sendOnlyErrorResponses, sendInvalidResponses)
@@ -155,13 +149,6 @@ class BankApiMockEngine {
                 }
             }
         }
-
-        installJsonFeature()
-
-        defaultRequest {
-            contentType(ContentType.Application.Json)
-        }
-    }
 
     private fun readBlockIdentifierFromRequest(request: HttpRequestData): String =
         request.extract<PostInvalidBlockRequest, String> { it.message.blockIdentifier }
@@ -183,92 +170,73 @@ class BankApiMockEngine {
     private fun patchBankEngine(
         enableErrorResponse: Boolean = false,
         sendInvalidResponses: Boolean = false
-    ) = HttpClient(MockEngine) {
+    ) = mockHttpClient.httpClient {
         val errorContent = BankAPIJsonMapper.mapInternalServerErrorToJson()
 
-        engine {
-            addHandler { request ->
-                when {
-                    request.url.encodedPath == BankAPIJsonMapper.BANKS_TRUST_ENDPOINT -> {
-                        val requestedTrust = readTrustFromRequest(request)
-                        val content = BankAPIJsonMapper.mapBankToJson(requestedTrust)
-                        val invalidContent = BankAPIJsonMapper.mapInvalidBankToJson()
-                        when {
-                            enableErrorResponse -> respond(
-                                errorContent,
-                                InternalServerError,
-                                responseHeaders
-                            )
-                            sendInvalidResponses -> respond(
-                                invalidContent,
-                                Accepted,
-                                responseHeaders
-                            )
-                            else -> respond(content, Accepted, responseHeaders)
-                        }
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.ACCOUNTS_ENDPOINT) -> {
-                        val requestedTrust = readTrustFromRequest(request)
-                        val responseBody = BankAPIJsonMapper.mapAccountToJson(trust = requestedTrust)
-                        when {
-                            enableErrorResponse -> respond(
-                                errorContent,
-                                InternalServerError,
-                                responseHeaders
-                            )
-                            sendInvalidResponses -> respond(
-                                BankAPIJsonMapper.mapEmptyAccountToJson(),
-                                Accepted,
-                                responseHeaders
-                            )
-                            else -> respond(responseBody, Accepted, responseHeaders)
-                        }
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.INVALID_BLOCKS_ENDPOINT) -> {
-                        val blockIdentifier = readBlockIdentifierFromRequest(request)
-                        val content = BankAPIJsonMapper.mapInvalidBlockToJson(blockIdentifier)
-                        val invalidContent = BankAPIJsonMapper.mapInvalidResponseForInvalidBlocksRequest()
-                        when {
-                            enableErrorResponse -> respond(errorContent, InternalServerError, responseHeaders)
-                            sendInvalidResponses -> respond(invalidContent, Accepted, responseHeaders)
-                            else -> respond(content, Accepted, responseHeaders)
-                        }
-                    }
-                    request.url.encodedPath.startsWith(BankAPIJsonMapper.BLOCKS_ENDPOINT) -> {
-                        val balanceKey = readBalanceKeyFromRequest(request)
-                        val content = BankAPIJsonMapper.mapBlockToJson(balanceKey)
-                        val invalidContent = BankAPIJsonMapper.mapBlockResponseForBlockRequest()
-                        when {
-                            enableErrorResponse -> respond(errorContent, InternalServerError, responseHeaders)
-                            sendInvalidResponses -> respond(invalidContent, Accepted, responseHeaders)
-                            else -> respond(content, Accepted, responseHeaders)
-                        }
-                    }
-                    else -> {
-                        error("Unhandled ${request.url.encodedPath}")
+        it.addHandler { request ->
+            when {
+                request.url.encodedPath == BankAPIJsonMapper.BANKS_TRUST_ENDPOINT -> {
+                    val requestedTrust = readTrustFromRequest(request)
+                    val content = BankAPIJsonMapper.mapBankToJson(requestedTrust)
+                    val invalidContent = BankAPIJsonMapper.mapInvalidBankToJson()
+                    when {
+                        enableErrorResponse -> respond(
+                            errorContent,
+                            InternalServerError,
+                            responseHeaders
+                        )
+                        sendInvalidResponses -> respond(
+                            invalidContent,
+                            Accepted,
+                            responseHeaders
+                        )
+                        else -> respond(content, Accepted, responseHeaders)
                     }
                 }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.ACCOUNTS_ENDPOINT) -> {
+                    val requestedTrust = readTrustFromRequest(request)
+                    val responseBody = BankAPIJsonMapper.mapAccountToJson(trust = requestedTrust)
+                    when {
+                        enableErrorResponse -> respond(
+                            errorContent,
+                            InternalServerError,
+                            responseHeaders
+                        )
+                        sendInvalidResponses -> respond(
+                            BankAPIJsonMapper.mapEmptyAccountToJson(),
+                            Accepted,
+                            responseHeaders
+                        )
+                        else -> respond(responseBody, Accepted, responseHeaders)
+                    }
+                }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.INVALID_BLOCKS_ENDPOINT) -> {
+                    val blockIdentifier = readBlockIdentifierFromRequest(request)
+                    val content = BankAPIJsonMapper.mapInvalidBlockToJson(blockIdentifier)
+                    val invalidContent = BankAPIJsonMapper.mapInvalidResponseForInvalidBlocksRequest()
+                    when {
+                        enableErrorResponse -> respond(errorContent, InternalServerError, responseHeaders)
+                        sendInvalidResponses -> respond(invalidContent, Accepted, responseHeaders)
+                        else -> respond(content, Accepted, responseHeaders)
+                    }
+                }
+                request.url.encodedPath.startsWith(BankAPIJsonMapper.BLOCKS_ENDPOINT) -> {
+                    val balanceKey = readBalanceKeyFromRequest(request)
+                    val content = BankAPIJsonMapper.mapBlockToJson(balanceKey)
+                    val invalidContent = BankAPIJsonMapper.mapBlockResponseForBlockRequest()
+                    when {
+                        enableErrorResponse -> respond(errorContent, InternalServerError, responseHeaders)
+                        sendInvalidResponses -> respond(invalidContent, Accepted, responseHeaders)
+                        else -> respond(content, Accepted, responseHeaders)
+                    }
+                }
+                else -> {
+                    error("Unhandled ${request.url.encodedPath}")
+                }
             }
-        }
-
-        installJsonFeature()
-
-        defaultRequest {
-            contentType(ContentType.Application.Json)
         }
     }
 
     private fun readTrustFromRequest(request: HttpRequestData): Double =
         request.extract<UpdateTrustRequest, Double> { it.message.trust }
-
-    private fun HttpClientConfig<MockEngineConfig>.installJsonFeature() {
-        install(JsonFeature) {
-            serializer = KotlinxSerializer(json())
-        }
-    }
-
-    private fun json(): Json = Json {
-        isLenient = true
-        ignoreUnknownKeys = true
-    }
 }

--- a/lib/src/test/java/com/thenewboston/utils/MockHttpClientManager.kt
+++ b/lib/src/test/java/com/thenewboston/utils/MockHttpClientManager.kt
@@ -1,0 +1,37 @@
+package com.thenewboston.utils
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.features.*
+import io.ktor.client.features.json.*
+import io.ktor.client.features.json.serializer.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+
+class MockHttpClientManager {
+
+    fun httpClient(callback: (MockEngineConfig) -> Unit): HttpClient {
+        return HttpClient(MockEngine) {
+            engine {
+                callback.invoke(this)
+            }
+
+            installJsonFeature()
+
+            defaultRequest {
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
+
+    private fun HttpClientConfig<MockEngineConfig>.installJsonFeature() {
+        install(JsonFeature) {
+            serializer = KotlinxSerializer(json())
+        }
+    }
+
+    private fun json(): Json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+}


### PR DESCRIPTION
* Added MockHttpClientManager to hold the instance of HttpClient. This can be further improved to be used as a factory class to create types for GET, POST or PATCH.
